### PR TITLE
assert in test_get_reference test updated since it expects 11 engines

### DIFF
--- a/tests/test_reference.py
+++ b/tests/test_reference.py
@@ -6,7 +6,7 @@ from aiomoex import reference
 async def test_get_reference(http_session):
     data = await reference.get_reference(http_session, "engines")
     assert isinstance(data, list)
-    assert len(data) == 10
+    assert len(data) == 11
     assert data[0] == {"id": 1, "name": "stock", "title": "Фондовый рынок и рынок депозитов"}
 
 


### PR DESCRIPTION
Greetings!

The [metadata endpoint](https://iss.moex.com/iss/index.json) currently returns 11 items in the [engines dictionary](https://iss.moex.com/iss/reference/28).

This PR updates the assertion for the `test_get_reference` test to align with the current metadata.